### PR TITLE
Read benchmarks

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,1 @@
+/sandbox

--- a/bench/all.js
+++ b/bench/all.js
@@ -1,7 +1,0 @@
-const heading = (name) => {
-  console.log(name)
-  console.log('-'.repeat(name.length) + '\n')
-}
-
-heading('Write performance')
-require('./write.js')

--- a/bench/all.js
+++ b/bench/all.js
@@ -1,0 +1,7 @@
+const heading = (name) => {
+  console.log(name)
+  console.log('-'.repeat(name.length) + '\n')
+}
+
+heading('Write performance')
+require('./write.js')

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -1,0 +1,70 @@
+const { createHistogram, timerify, PerformanceObserver } = require('perf_hooks')
+const { formatNanoseconds } = require('./util.js')
+
+function noop() {}
+
+// Options:
+//   name: string, name of benchmark
+//   cycle: function to time, receives return value of setup() as only argument
+//
+//   [setup]: function to run before each cycle (not timed), receives one argument the input data for the current variation
+//   [teardown]: function to run after each cycle (not timed), receives return value of setup() as only argument
+//   [count]: number of times to run the cycle function (after warmup)
+//   [warmup]: number of times to run cycle function before timing starts
+//   [variations]: object mapping names to input data
+async function bench(options) {
+  const {
+    name,
+    cycle,
+    count = 10,
+    warmup = 1,
+    setup = noop,
+    teardown = noop,
+    variations = { '': null }
+  } = options
+
+  console.log(name)
+  const results = {}
+  const histograms = {}
+
+  for (const v of Object.keys(variations)) {
+    const input = variations[v]
+
+    // Warmup
+    for (let i = 0; i < warmup; i++) {
+      const context = await setup(input)
+      await cycle(context)
+      await teardown(context)
+    }
+
+    // Time cycles
+    const histogram = createHistogram()
+    const wrapped = timerify(options.cycle, { histogram })
+
+    const observer = new PerformanceObserver(() => {})
+    observer.observe({ entryTypes: ['function'] })
+
+    for (let i = 0; i < count; i++) {
+      const context = await setup(input)
+      await wrapped(context)
+      await teardown(context)
+    }
+
+    results[v] = {
+      cycles: histogram.count,
+      mean: formatNanoseconds(histogram.mean),
+      min: formatNanoseconds(histogram.min),
+      max: formatNanoseconds(histogram.max),
+      stddev: formatNanoseconds(histogram.stddev)
+    }
+    histograms[v] = histogram
+    observer.disconnect()
+  }
+
+  console.table(results)
+  console.log()
+
+  return histograms
+}
+
+module.exports = { bench }

--- a/bench/read.js
+++ b/bench/read.js
@@ -1,0 +1,114 @@
+// Write performance benchmarks
+const Hyperbee = require('../index.js')
+const Corestore = require('corestore')
+const { randomBytes } = require('crypto')
+const { bench } = require('./bench.js')
+const { resolve } = require('path')
+const { clearSandbox } = require('./util.js')
+const { openRocksDB } = require('./rocks.js')
+
+const ROCKSDB_PATH = resolve(__dirname, './sandbox/read/rocksdb')
+const HB2_PATH = resolve(__dirname, './sandbox/read/hb2')
+
+const random = []
+for (let i = 0; i < 100_000; i++) {
+  random.push([randomBytes(1024), randomBytes(1024)])
+}
+
+const ascending = random.slice()
+ascending.sort((a, b) => Buffer.compare(a[0], b[0]))
+
+const descending = ascending.slice()
+descending.reverse()
+
+async function populateRocksDB() {
+  await clearSandbox(ROCKSDB_PATH)
+  const { rocks, db } = await openRocksDB(ROCKSDB_PATH)
+
+  // Write all items to (random order)
+  const w = db.write()
+  for (const [k, v] of random) {
+    w.put(k, v)
+  }
+  await w.flush()
+  w.destroy()
+
+  return { rocks, db }
+}
+
+async function populateHyperbee2() {
+  await clearSandbox(HB2_PATH)
+  const b = new Hyperbee(new Corestore(HB2_PATH))
+  await b.ready()
+
+  // Write all items to (random order)
+  const w = b.write()
+  for (const [k, v] of random) {
+    w.tryPut(k, v)
+  }
+  await w.flush()
+
+  return b
+}
+
+async function run() {
+  const { rocks, db } = await populateRocksDB()
+  const b = await populateHyperbee2()
+
+  await bench({
+    name: `RocksDB: get 100K keys`,
+    variations: { ascending, descending, random },
+    count: 10,
+    setup(source) {
+      return source
+    },
+    async cycle(source) {
+      const r = db.read()
+      for (const [k, _v] of source) {
+        const p = r.get(k)
+        r.flush()
+        await p
+      }
+    }
+  })
+
+  await bench({
+    name: `Hyperbee2: get 100K keys`,
+    variations: { ascending, descending, random },
+    count: 10,
+    setup(source) {
+      return source
+    },
+    async cycle(source) {
+      for (const [k, _v] of source) {
+        const p = b.get(k)
+        await p
+      }
+    }
+  })
+
+  await bench({
+    name: `RocksDB: iterate over 100K keys`,
+    count: 10,
+    async cycle() {
+      for await (const data of db.iterator()) {
+        const _ = data.key
+      }
+    }
+  })
+
+  await bench({
+    name: `Hyperbee2: iterate over 100K keys`,
+    count: 10,
+    async cycle() {
+      for await (const data of b.createReadStream()) {
+        const _ = data.key
+      }
+    }
+  })
+
+  await rocks.close()
+  await b.close()
+}
+
+run()

--- a/bench/rocks.js
+++ b/bench/rocks.js
@@ -1,0 +1,23 @@
+const RocksDB = require('rocksdb-native')
+
+async function openRocksDB(path) {
+  const rocks = new RocksDB(path, { createIfMissing: true })
+  // Get an approximation of corestore's rocksdb use
+  // See: https://github.com/holepunchto/hypercore-storage/blob/4e8262299837a588a58c160ca943350a4c41bf97/index.js#L1051
+  const col = new RocksDB.ColumnFamily('not-corestore', {
+    enableBlobFiles: true,
+    minBlobSize: 4096,
+    blobFileSize: 256 * 1024 * 1024,
+    enableBlobGarbageCollection: true,
+    tableBlockSize: 8192,
+    tableCacheIndexAndFilterBlocks: true,
+    tableFormatVersion: 6,
+    optimizeFiltersForMemory: false,
+    blockCache: true
+  })
+  const db = rocks.columnFamily(col)
+  await db.ready()
+  return { rocks, db }
+}
+
+module.exports = { openRocksDB }

--- a/bench/util.js
+++ b/bench/util.js
@@ -1,0 +1,48 @@
+const { rm, mkdir } = require('fs/promises')
+
+// Randomize array in-place using Durstenfeld shuffle algorithm
+function shuffle(arr) {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    const tmp = arr[i]
+    arr[i] = arr[j]
+    arr[j] = tmp
+  }
+}
+
+function _pick1KUnit(units, value) {
+  let m = 0
+  while (m < units.length - 1 && value > 1000) {
+    value = value / 1000
+    m++
+  }
+  return value.toPrecision(3) + units[m]
+}
+
+function humanizeCount(count) {
+  return _pick1KUnit(['', 'K', 'M'], count)
+}
+
+function formatNanoseconds(value) {
+  return _pick1KUnit(['ns', 'µs', 'ms', 's'], value)
+}
+
+async function clearSandbox(path) {
+  await rm(path, { recursive: true })
+  await mkdir(path, { recursive: true })
+}
+
+function compareResults(rocks, hb2) {
+  const rows = {}
+  for (const name of Object.keys(rocks)) {
+    rows[name] = {
+      'RocksDB (mean)': formatNanoseconds(rocks[name].mean),
+      'Hyperbee2 (mean)': formatNanoseconds(hb2[name].mean),
+      overhead: Math.round((hb2[name].mean / rocks[name].mean) * 100 - 100) + '%'
+    }
+  }
+  console.table(rows)
+  console.log()
+}
+
+module.exports = { shuffle, humanizeCount, formatNanoseconds, clearSandbox, compareResults }

--- a/bench/util.js
+++ b/bench/util.js
@@ -28,7 +28,11 @@ function formatNanoseconds(value) {
 }
 
 async function clearSandbox(path) {
-  await rm(path, { recursive: true })
+  try {
+    await rm(path, { recursive: true })
+  } catch (e) {
+    if (e.code !== 'ENOENT') throw e
+  }
   await mkdir(path, { recursive: true })
 }
 

--- a/bench/write.js
+++ b/bench/write.js
@@ -1,0 +1,172 @@
+// Write performance benchmarks
+const Hyperbee = require('../index.js')
+const Corestore = require('corestore')
+const { randomBytes } = require('crypto')
+const { bench } = require('./bench.js')
+const { resolve } = require('path')
+const { shuffle, clearSandbox, compareResults } = require('./util.js')
+const { openRocksDB } = require('./rocks.js')
+
+const PATH = resolve(__dirname, './sandbox/write')
+
+function makeVariations(count, item) {
+  const ascending = []
+  for (let i = 0; i < count; i++) {
+    ascending[i] = item(i)
+  }
+
+  const random = ascending.slice()
+  shuffle(random)
+
+  const descending = ascending.slice()
+  descending.reverse()
+
+  return { ascending, descending, random }
+}
+
+async function run() {
+  const rocks_small_kv_large_batch = await bench({
+    name: `RocksDB: insert 100K small keys and values in one large batch`,
+    count: 10,
+    variations: makeVariations(100_000, (i) => [Buffer.from('#' + i), Buffer.from('#' + i)]),
+    async setup(source) {
+      await clearSandbox(PATH)
+      const { rocks, db } = await openRocksDB(PATH)
+      return { rocks, db, source }
+    },
+    async cycle({ db, source }) {
+      const w = db.write()
+      for (const [k, v] of source) {
+        w.put(k, v)
+      }
+      await w.flush()
+      w.destroy()
+    },
+    async teardown({ rocks }) {
+      await rocks.close()
+    }
+  })
+
+  const hb2_small_kv_large_batch = await bench({
+    name: `Hyperbee2: insert 100K small keys and values in one large batch`,
+    count: 10,
+    variations: makeVariations(100_000, (i) => [Buffer.from('#' + i), Buffer.from('#' + i)]),
+    async setup(source) {
+      await clearSandbox(PATH)
+      const b = new Hyperbee(new Corestore(PATH))
+      await b.ready()
+      return { b, source }
+    },
+    async cycle({ b, source }) {
+      const w = b.write()
+      for (const [k, v] of source) {
+        w.tryPut(k, v)
+      }
+      await w.flush()
+    },
+    async teardown({ b }) {
+      await b.close()
+    }
+  })
+
+  compareResults(rocks_small_kv_large_batch, hb2_small_kv_large_batch)
+
+  const rocks_small_kv_small_batch = await bench({
+    name: `RocksDB: insert 10K small keys and values each in a separate batch`,
+    count: 10,
+    variations: makeVariations(10_000, (i) => [Buffer.from('#' + i), Buffer.from('#' + i)]),
+    async setup(source) {
+      await clearSandbox(PATH)
+      const { rocks, db } = await openRocksDB(PATH)
+      return { rocks, db, source }
+    },
+    async cycle({ db, source }) {
+      for (const [k, v] of source) {
+        const w = db.write()
+        w.put(k, v)
+        await w.flush()
+        w.destroy()
+      }
+    },
+    async teardown({ rocks }) {
+      await rocks.close()
+    }
+  })
+
+  const hb2_small_kv_small_batch = await bench({
+    name: `Hyperbee2: insert 10K small keys and values each in a separate batch`,
+    count: 10,
+    variations: makeVariations(10_000, (i) => [Buffer.from('#' + i), Buffer.from('#' + i)]),
+    async setup(source) {
+      await clearSandbox(PATH)
+      const b = new Hyperbee(new Corestore(PATH))
+      await b.ready()
+      return { b, source }
+    },
+    async cycle({ b, source }) {
+      for (const [k, v] of source) {
+        const w = b.write()
+        w.tryPut(k, v)
+        await w.flush()
+      }
+    },
+    async teardown({ b }) {
+      await b.close()
+    }
+  })
+
+  compareResults(rocks_small_kv_small_batch, hb2_small_kv_small_batch)
+
+  const random_large_kv = []
+  for (let i = 0; i < 100; i++) {
+    random_large_kv.push([randomBytes(1024 * 1024), randomBytes(1024 * 1024)])
+  }
+
+  const rocks_large_kv_small_batch = await bench({
+    name: `RocksDB: insert 100 large (1MB) keys and values each in a separate batch`,
+    count: 10,
+    variations: { random: random_large_kv },
+    async setup(source) {
+      await clearSandbox(PATH)
+      const { rocks, db } = await openRocksDB(PATH)
+      return { rocks, db, source }
+    },
+    async cycle({ db, source }) {
+      for (const [k, v] of source) {
+        const w = db.write()
+        w.put(k, v)
+        await w.flush()
+        w.destroy()
+      }
+    },
+    async teardown({ rocks }) {
+      await rocks.close()
+    }
+  })
+
+  const hb2_large_kv_small_batch = await bench({
+    name: `Hyperbee2: insert 100 large (1MB) keys and values each in a separate batch`,
+    count: 10,
+    variations: { random: random_large_kv },
+    async setup(source) {
+      await clearSandbox(PATH)
+      const b = new Hyperbee(new Corestore(PATH))
+      await b.ready()
+      return { b, source }
+    },
+    async cycle({ b, source }) {
+      for (const [k, v] of source) {
+        const w = b.write()
+        w.tryPut(k, v)
+        await w.flush()
+      }
+    },
+    async teardown({ b }) {
+      await b.close()
+    }
+  })
+
+  compareResults(rocks_large_kv_small_batch, hb2_large_kv_small_batch)
+}
+
+run()

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "lunte && prettier . --check",
     "test": "node test/all.js",
     "test:bare": "bare test/all.js",
-    "test:generate": "brittle -r test/all.js test/*.js"
+    "test:generate": "brittle -r test/all.js test/*.js",
+    "bench": "node bench/all.js"
   },
   "dependencies": {
     "b4a": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "node test/all.js",
     "test:bare": "bare test/all.js",
     "test:generate": "brittle -r test/all.js test/*.js",
-    "bench": "node bench/all.js"
+    "bench": "node bench/write.js && node bench/read.js"
   },
   "dependencies": {
     "b4a": "^1.6.7",


### PR DESCRIPTION
Times ascending, descending, random get() calls and iteration over keys.

Run as part of `npm run bench`

This branch was written on top of the write-benchmarks branch. See earlier pull request.