### PR TITLE
Bug getblock concurrency

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -30,6 +30,7 @@ class CoreContext {
     this.opened = []
     this.cores = []
     this.changed = false
+    this.inProgress = new Map()
   }
 
   // TODO: remove, left here for easier debugging for now
@@ -155,17 +156,28 @@ class CoreContext {
     return this.cores[index - 1].key
   }
 
-  async getBlock(seq, core, config) {
-    if (core !== 0 && core - 1 >= this.cores.length) await this.update(config)
+  getBlock(seq, core, config) {
+    if (!this.inProgress.has(core)) {
+      this.inProgress.set(core, new Map())
+    }
+    if (this.inProgress.get(core).has(seq)) {
+      return this.inProgress.get(core).get(seq)
+    }
+    const promise = (async () => {
+      if (core !== 0 && core - 1 >= this.cores.length) await this.update(config)
 
-    const hc = this.getCore(core)
-    const buffer = await hc.get(seq, config)
-    if (buffer === null) throw BLOCK_NOT_AVAILABLE()
+      const hc = this.getCore(core)
+      const buffer = await hc.get(seq, config)
+      if (buffer === null) throw BLOCK_NOT_AVAILABLE()
 
-    if (config.trace !== null) config.trace(core, seq)
+      if (config.trace !== null) config.trace(core, seq)
 
-    const block = decodeBlock(buffer, seq)
-    return block
+      const block = decodeBlock(buffer, seq)
+      this.inProgress.get(core).delete(seq)
+      return block
+    })()
+    this.inProgress.get(core).set(seq, promise)
+    return promise
   }
 
   getLocalContext() {

--- a/lib/context.js
+++ b/lib/context.js
@@ -30,7 +30,6 @@ class CoreContext {
     this.opened = []
     this.cores = []
     this.changed = false
-    this.inProgress = new Map()
   }
 
   // TODO: remove, left here for easier debugging for now
@@ -156,28 +155,17 @@ class CoreContext {
     return this.cores[index - 1].key
   }
 
-  getBlock(seq, core, config) {
-    if (!this.inProgress.has(core)) {
-      this.inProgress.set(core, new Map())
-    }
-    if (this.inProgress.get(core).has(seq)) {
-      return this.inProgress.get(core).get(seq)
-    }
-    const promise = (async () => {
-      if (core !== 0 && core - 1 >= this.cores.length) await this.update(config)
+  async getBlock(seq, core, config) {
+    if (core !== 0 && core - 1 >= this.cores.length) await this.update(config)
 
-      const hc = this.getCore(core)
-      const buffer = await hc.get(seq, config)
-      if (buffer === null) throw BLOCK_NOT_AVAILABLE()
+    const hc = this.getCore(core)
+    const buffer = await hc.get(seq, config)
+    if (buffer === null) throw BLOCK_NOT_AVAILABLE()
 
-      if (config.trace !== null) config.trace(core, seq)
+    if (config.trace !== null) config.trace(core, seq)
 
-      const block = decodeBlock(buffer, seq)
-      this.inProgress.get(core).delete(seq)
-      return block
-    })()
-    this.inProgress.get(core).set(seq, promise)
-    return promise
+    const block = decodeBlock(buffer, seq)
+    return block
   }
 
   getLocalContext() {

--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -2,9 +2,21 @@ const b4a = require('b4a')
 const { Pointer, KeyPointer, ValuePointer, TreeNode } = require('./tree.js')
 const { DeltaOp, DeltaCohort, OP_COHORT } = require('./compression.js')
 
+const pending = new WeakMap()
+
 exports.inflate = async function inflate(ptr, config) {
   if (ptr.value) return ptr.value
+  if (pending.has(ptr)) return pending.get(ptr)
+  const promise = _inflate(ptr, config)
+  pending.set(ptr, promise)
+  try {
+    return await promise
+  } finally {
+    pending.delete(ptr)
+  }
+}
 
+async function _inflate(ptr, config) {
   const [block, context] = await Promise.all([
     ptr.context.getBlock(ptr.seq, ptr.core, config),
     ptr.context.getContext(ptr.core, config)


### PR DESCRIPTION
Related to: https://github.com/holepunchto/hyperdb/pull/91 - If you change `while (i < 300_000)` to `while (i < 300_001)` and run it again you'll get an out of memory (OOM) error.

It appears there are a bunch of promises for getBlock() being queued up without waiting for in-flight ones to resolve, eventually resulting in OOM.

I've added a temporary workaround that avoids OOM by keeping a register of in-flight getBlock requests in context and returning existing promises when possible... (often the same block is being requested but not awaited before more requests are queued).

I'm not recommending the workaround be merged at this point. Instead, this bug indicates to me some better concurrency control is needed somewhere and there may be more structural problems to fix first.