### PR TITLE
Failing tests for put edgecases

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -864,27 +864,6 @@ test('trace', async function (t) {
   t.alike(seqs, new Set([0, 1]))
 })
 
-test('repeated put with null value', async function (t) {
-  const db = await create(t)
-
-  const hello = b4a.from('hello')
-  {
-    const w = db.write()
-    w.tryPut(hello, null)
-    await w.flush()
-  }
-
-  t.is((await db.get(hello)).value, null, 'got null value')
-
-  // Previous behaviour was a crash
-  {
-    const w = db.write()
-    w.tryPut(hello, null)
-    await w.flush()
-  }
-
-  t.is((await db.get(hello)).value, null, 'got null value')
-})
 
 test('repeated put with empty buffer value after reload of storage', async function (t) {
   const storage = await t.tmp()

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,7 @@
 const test = require('brittle')
 const b4a = require('b4a')
+const Corestore = require('corestore')
+const Bee = require('../')
 const { create, replicate } = require('./helpers')
 
 test('basic', async function (t) {
@@ -860,4 +862,81 @@ test('trace', async function (t) {
   }
 
   t.alike(seqs, new Set([0, 1]))
+})
+
+test('repeated put with null value', async function (t) {
+  const db = await create(t)
+
+  const hello = b4a.from('hello')
+  {
+    const w = db.write()
+    w.tryPut(hello, null)
+    await w.flush()
+  }
+
+  t.is((await db.get(hello)).value, null, 'got null value')
+
+  // Previous behaviour was a crash
+  {
+    const w = db.write()
+    w.tryPut(hello, null)
+    await w.flush()
+  }
+
+  t.is((await db.get(hello)).value, null, 'got null value')
+})
+
+test('repeated put with empty buffer value after reload of storage', async function (t) {
+  const storage = await t.tmp()
+  const hello = b4a.from('hello')
+
+  {
+    const store = new Corestore(storage)
+    const db = new Bee(store)
+
+    {
+      const w = db.write()
+      await w.lock()
+
+      w.tryPut(hello, b4a.alloc(0))
+      await w.flush()
+    }
+    t.alike((await db.get(hello)).value, b4a.alloc(0), 'got empty buffer value')
+
+    {
+      const w = db.write()
+      await w.lock()
+
+      w.tryPut(hello, b4a.alloc(0))
+      await w.flush()
+    }
+
+    t.alike(
+      (await db.get(hello)).value,
+      b4a.alloc(0),
+      'got empty buffer value after second put during same lifecycle'
+    )
+
+    await db.close()
+    await store.close()
+  }
+
+  {
+    const store = new Corestore(storage)
+    const db = new Bee(store)
+
+    // Previous behaviour was a crash
+    {
+      const w = db.write()
+      await w.lock()
+
+      w.tryPut(hello, b4a.alloc(0))
+      await w.flush()
+    }
+
+    t.alike((await db.get(hello)).value, b4a.alloc(0), 'got empty buffer value after reloading')
+
+    await db.close()
+    await store.close()
+  }
 })

--- a/test/basic.js
+++ b/test/basic.js
@@ -881,7 +881,6 @@ test('repeated put with empty buffer value after reload of storage', async funct
     }
     t.alike((await db.get(hello)).value, b4a.alloc(0), 'got empty buffer value')
 
-
     await db.close()
     await store.close()
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -882,19 +882,6 @@ test('repeated put with empty buffer value after reload of storage', async funct
     }
     t.alike((await db.get(hello)).value, b4a.alloc(0), 'got empty buffer value')
 
-    {
-      const w = db.write()
-      await w.lock()
-
-      w.tryPut(hello, b4a.alloc(0))
-      await w.flush()
-    }
-
-    t.alike(
-      (await db.get(hello)).value,
-      b4a.alloc(0),
-      'got empty buffer value after second put during same lifecycle'
-    )
 
     await db.close()
     await store.close()


### PR DESCRIPTION
The first one might be undefined behaviour, if only buffer values are supported.

The second one is quite worrying: behaviour shouldn't change after re-opening storage.

A trivial fix is adding a guard here: https://github.com/holepunchto/hyperbee2/blob/be37588a21cfbe88b6ba741688755ecb38fac090/lib/write.js#L171, but that would just work around the issue, so i don't think it's the correct fix.