### PR TITLE
Skip setting root if context locked

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,10 @@ class Hyperbee extends EventEmitter {
   }
 
   update(root = null) {
-    if (root === null) root = this._lastNodeInCore()
+    if (root === null) {
+      if (this.context.lock.locked) return
+      root = this._lastNodeInCore()
+    }
     this._setRoot(root, true)
   }
 

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -83,6 +83,15 @@ class TreeNodePointer extends Pointer {
     return ptr
   }
 
+  equivalentTo(other) {
+    return (
+      super.equivalentTo(other) &&
+      this.value === other.value &&
+      this.prev === other.prev &&
+      this.next === other.next
+    )
+  }
+
   // TODO: remove, left here for easier debugging for now
   [Symbol.for('nodejs.util.inspect.custom')]() {
     return `[TreeNodePointer core=${this.core} seq=${this.seq} offset=${this.offset} changed=${this.changed}]`

--- a/test/all.js
+++ b/test/all.js
@@ -10,6 +10,7 @@ async function runTests() {
   await import('./basic.js')
   await import('./diff.js')
   await import('./fuzz.js')
+  await import('./tree.js')
   await import('./undo.js')
 
   test.resume()

--- a/test/basic.js
+++ b/test/basic.js
@@ -861,3 +861,18 @@ test('trace', async function (t) {
 
   t.alike(seqs, new Set([0, 1]))
 })
+
+test('autoUpdate doesnt lose data', async function (t) {
+  const db = await create(t, { autoUpdate: true })
+  await db.ready()
+
+  {
+    const w = db.write()
+    w.tryPut(b4a.from('1'), b4a.from('1'))
+    w.tryPut(b4a.from('2'), b4a.from('2'))
+    await w.flush()
+  }
+
+  t.alike((await db.get(b4a.from('1'))).value, b4a.from('1'))
+  t.alike((await db.get(b4a.from('2'))).value, b4a.from('2'))
+})

--- a/test/tree.js
+++ b/test/tree.js
@@ -1,0 +1,15 @@
+const test = require('brittle')
+const { TreeNode } = require('../lib/tree.js')
+const { create } = require('./helpers/index.js')
+
+test('TreeNodePointer - equivalentTo', async function (t) {
+  const db = await create(t)
+  await db.ready()
+
+  const ptr = db.context.createTreeNode(0, 0, 0, false, null)
+  t.ok(ptr.equivalentTo(ptr), 'equal to self')
+
+  // Create same pointer w/ value
+  const ptr2 = db.context.createTreeNode(0, 0, 0, false, new TreeNode([], []))
+  t.absent(ptr.equivalentTo(ptr2), 'not equal w/ different values')
+})


### PR DESCRIPTION
`core.on('append'` triggeres `update()` regardless of whether or not there is already an update in progress. This results in autoUpdate causing data loss.

This was revealed via HyperDB tests. `insert/flush/get` was failing only when `autoUpdate` was on.
When off, manually calling `update()` was failing.