### PR TITLE
Check TreeNodePointer's `value`, `prev` & `next` in `equivalentTo`

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -83,6 +83,15 @@ class TreeNodePointer extends Pointer {
     return ptr
   }
 
+  equivalentTo(other) {
+    return (
+      super.equivalentTo(other) &&
+      this.value === other.value &&
+      this.prev === other.prev &&
+      this.next === other.next
+    )
+  }
+
   // TODO: remove, left here for easier debugging for now
   [Symbol.for('nodejs.util.inspect.custom')]() {
     return `[TreeNodePointer core=${this.core} seq=${this.seq} offset=${this.offset} changed=${this.changed}]`

--- a/test/all.js
+++ b/test/all.js
@@ -10,6 +10,7 @@ async function runTests() {
   await import('./basic.js')
   await import('./diff.js')
   await import('./fuzz.js')
+  await import('./tree.js')
   await import('./undo.js')
 
   test.resume()

--- a/test/tree.js
+++ b/test/tree.js
@@ -11,5 +11,5 @@ test('TreeNodePointer - equivalentTo', async function (t) {
 
   // Create same pointer w/ value
   const ptr2 = db.context.createTreeNode(0, 0, 0, false, new TreeNode([], []))
-  t.absent(ptr.equivalentTo(ptr2), 'not equal')
+  t.absent(ptr.equivalentTo(ptr2), 'not equal w/ different values')
 })

--- a/test/tree.js
+++ b/test/tree.js
@@ -1,0 +1,15 @@
+const test = require('brittle')
+const { TreeNode } = require('../lib/tree.js')
+const { create } = require('./helpers/index.js')
+
+test('TreeNodePointer - equivalentTo', async function (t) {
+  const db = await create(t)
+  await db.ready()
+
+  const ptr = db.context.createTreeNode(0, 0, 0, false, null)
+  t.ok(ptr.equivalentTo(ptr), 'equal to self')
+
+  // Create same pointer w/ value
+  const ptr2 = db.context.createTreeNode(0, 0, 0, false, new TreeNode([], []))
+  t.absent(ptr.equivalentTo(ptr2), 'not equal')
+})


### PR DESCRIPTION
Previously it uses only the `Pointer` implementation which doesnt factor in the `value` which lead to data loss when no guard against lock.

While skipping updating the root when the context is locked makes sense, the final root was called after the root set by the `append` listener. Why it didn't take was because of the equivalence check didn't factor `TreeNodePointer` specifics.

This `equivalentTo` update negates the need for the lock check in the situation where data was lost, but makes the lock check required now for the tests verifying `update` events dont over fire. (Such as `emit update event after remote append to non-empty tree and autoUpdate` and others from #33 ) 