### PR TITLE
Update `publish.yml` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
       - v*
 permissions:
   id-token: write
-  contents: read
+  contents: write
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -14,4 +14,4 @@ jobs:
     name: Publish
     steps:
       - uses: holepunchto/actions/node-base@v1
-      - run: npm publish --ignore-scripts
+      - uses: holepunchto/actions/publish@v1


### PR DESCRIPTION
Now uses [`holepunchto/actions/publish@v1`](https://github.com/holepunchto/actions/blob/main/publish/action.yml) which includes creating a github release.