### PR TITLE
Inflate `KeyPointer`s w/ `value = null` as empty buffers

### DIFF
--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -55,7 +55,7 @@ async function inflateKeyDelta(context, d, ptr, block, config) {
     const p = bk.valuePointer
     const ctx = await context.getContext(k.core, config)
     vp = new ValuePointer(ctx, p.core, p.seq, p.offset, p.split)
-  }
+  } else if (bk.value === null) bk.value = b4a.alloc(0)
 
   const kp = new KeyPointer(context, k.core, k.seq, k.offset, false, bk.key, bk.value, vp)
   return new DeltaOp(false, d.type, d.index, kp)


### PR DESCRIPTION
When the value is checked against an `existing` value, it is assumed to be a buffer. Since empty buffers are encoded the same as `null` & decode as `null`, this means using `b4a.equals()` throws ([here](https://github.com/holepunchto/hyperbee2/blob/main/lib/write.js#L150) & [here](https://github.com/holepunchto/hyperbee2/blob/8c0d620e2c9fda5932d00df89737abb687cfca06/lib/write.js#L171)). It is assumed that all `value`s for a `key` should be a buffer since `null` is not supported when putting a value for a key.

This fix also fixes a scenario in `hyperdb`'s `enum as key type` test when run with `hyperbee2` because value of `null` is treated as a missing entry.