### PR TITLE
Bump `compact-encoding` to `3.0.0` for strict `buffer` encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "b4a": "^1.6.7",
     "bare-events": "^2.8.2",
-    "compact-encoding": "^2.16.1",
+    "compact-encoding": "^3.0.0",
     "hypercore": "^11.15.0",
     "hypercore-errors": "^1.5.0",
     "hyperschema": "^1.14.0",


### PR DESCRIPTION
Fixes #43's issue as well since the `value` property of `@bee/key` is now a strict `buffer` (ie can't encode `null`).