### PR TITLE
always pass key to write batch

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,7 @@ class Hyperbee extends EventEmitter {
 
   write(opts) {
     if (!this.writable) throw new Error('Not writable')
+    opts.key = this.head().key
     return new WriteBatch(this, opts)
   }
 

--- a/index.js
+++ b/index.js
@@ -132,9 +132,9 @@ class Hyperbee extends EventEmitter {
     return this._makeView(this.context, this.root, true, n)
   }
 
-  write(opts) {
+  write(opts = {}) {
     if (!this.writable) throw new Error('Not writable')
-    opts.key = this.head().key
+    opts.key = opts.key || this.head().key
     return new WriteBatch(this, opts)
   }
 

--- a/index.js
+++ b/index.js
@@ -134,7 +134,9 @@ class Hyperbee extends EventEmitter {
 
   write(opts = {}) {
     if (!this.writable) throw new Error('Not writable')
-    opts.key = opts.key || this.head().key
+    if (!opts.key) {
+      opts.key = this.root ? this.head().key : null
+    }
     return new WriteBatch(this, opts)
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -801,6 +801,39 @@ test('move to current head() does not emit update event', async function (t) {
   t.alike(counter, 1)
 })
 
+test('move - write w/ key after move defaults to head\'s key', async function (t) {
+  const db = await create(t)
+  await db.ready()
+
+  {
+    const w = db.write()
+    w.tryPut(b4a.from('hello'), b4a.from('world'))
+    await w.flush()
+  }
+
+  let counter = 0
+  const db2 = await create(t)
+
+  replicate(t, db, db2)
+
+  await db2.ready()
+
+  // Both db and db2 head now have length=1 (but different keys).
+  const dbHead = db.head()
+  db2.move(dbHead)
+
+  t.alike((await db2.get(b4a.from('hello')))?.value, b4a.from('world'))
+
+  {
+    const w = db2.write()
+    t.alike(w.key, dbHead.key, 'new write is using db head')
+    w.tryPut(b4a.from('hello'), b4a.from('world!!!'))
+    await w.flush()
+  }
+
+  t.alike((await db2.get(b4a.from('hello')))?.value, b4a.from('world!!!'))
+})
+
 test('RangeIterator.prefetchNext with upper bound', async function (t) {
   const db = await create(t)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -801,7 +801,7 @@ test('move to current head() does not emit update event', async function (t) {
   t.alike(counter, 1)
 })
 
-test('move - write w/ key after move defaults to head\'s key', async function (t) {
+test("move - write w/ key after move defaults to head's key", async function (t) {
   const db = await create(t)
   await db.ready()
 
@@ -811,7 +811,6 @@ test('move - write w/ key after move defaults to head\'s key', async function (t
     await w.flush()
   }
 
-  let counter = 0
   const db2 = await create(t)
 
   replicate(t, db, db2)


### PR DESCRIPTION
If the user does not correctly pass `key` option to a write batch after a `move` operation, then the `block.previous` defaults to the local core instead of the core we moved to, which is incorrect and corrupts the tree