### PR TITLE
Fix stale cache after move operation

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,10 @@ class Hyperbee extends EventEmitter {
   move({ length = this.core.length, key = null, writable = this.writable } = {}) {
     this.context = key ? this.context.getContextByKey(key) : this.context
     this.writable = writable
+
+    const sameCore = key === null || b4a.equals(key, this.core.key)
+    if (!sameCore || length < this.core.length) this.context.cache.empty()
+
     this._setRoot(this._nodeAtSeq(length - 1), true)
   }
 

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -51,7 +51,7 @@ class CompressedArray {
     c.delta = this.delta
     c.entries = this.uentries || this.entries.slice(0)
 
-    this.delta = this.delta.slice(0, -this.updates)
+    this.delta = this.updates === 0 ? this.delta.slice(0) : this.delta.slice(0, -this.updates)
     this.uentries = null
     this.updates = 0
 

--- a/test/move.js
+++ b/test/move.js
@@ -1,0 +1,81 @@
+const test = require('brittle')
+const b4a = require('b4a')
+const { create } = require('./helpers')
+const { CompressedArray, DeltaOp, OP_INSERT } = require('../lib/compression.js')
+
+test('move back and flush, disk state stays intact', async function (t) {
+  const db = await create(t)
+
+  const pad = (n) => 'key/' + String(n).padStart(5, '0')
+  const model = new Map()
+
+  {
+    const w = db.write()
+    for (let i = 0; i < 400; i++) {
+      w.tryPut(b4a.from(pad(i)), b4a.from('v0-' + i))
+      model.set(pad(i), 'v0-' + i)
+    }
+    await w.flush()
+  }
+
+  const touched = (f) => {
+    const idxs = []
+    for (let i = 0; i < 5; i++) idxs.push((f * 37 + i * 11) % 400)
+    return idxs
+  }
+
+  for (let f = 1; f <= 10; f++) {
+    const w = db.write()
+    for (const idx of touched(f)) {
+      w.tryPut(b4a.from(pad(idx)), b4a.from(`v${f}-${idx}`))
+      model.set(pad(idx), `v${f}-${idx}`)
+    }
+    await w.flush()
+  }
+
+  db.move({ length: db.head().length - 1 })
+
+  for (const idx of touched(10)) {
+    let val = 'v0-' + idx
+    for (let f = 1; f <= 9; f++) {
+      if (touched(f).includes(idx)) val = `v${f}-${idx}`
+    }
+    model.set(pad(idx), val)
+  }
+
+  {
+    const w = db.write()
+    for (let i = 0; i < 5; i++) {
+      const idx = (900 + i * 13) % 400
+      w.tryPut(b4a.from(pad(idx)), b4a.from('vpost-' + idx))
+      model.set(pad(idx), 'vpost-' + idx)
+    }
+    await w.flush()
+  }
+
+  db.cache.empty()
+
+  let bad = 0
+  for (const [key, value] of model) {
+    const node = await db.get(b4a.from(key))
+    const got = node ? b4a.toString(node.value) : null
+    if (got !== value) bad++
+  }
+
+  t.is(bad, 0)
+})
+
+test('compressed array commit without updates keeps the delta', function (t) {
+  const arr = new CompressedArray([
+    new DeltaOp(false, OP_INSERT, 0, {}),
+    new DeltaOp(false, OP_INSERT, 1, {}),
+    new DeltaOp(false, OP_INSERT, 2, {})
+  ])
+
+  const c = arr.commit()
+
+  t.is(c.delta.length, 3)
+  t.is(arr.delta.length, 3)
+  t.ok(c.delta !== arr.delta)
+  t.is(arr.entries.length, 3)
+})


### PR DESCRIPTION
- WriteBatch serialization renumbers pointer objects in place (k.seq/k.offset = <new block positions>), and those objects are shared into older nodes' delta lists through CompressedArray.commit(). The decoder rebuilds nodes purely from their own block's delta list, so the in-memory delta is what gets serialized. The design assumption is that an old node object is never re-serialized after a newer flush and autobee's undo (move() to an older length) violates exactly that: the node cache hands back the old root object whose delta pointers now reference the newer, just-abandoned block, and the post-undo re-apply flushes garbage references to disk.

- commit()'s slice(0, -this.updates) with updates === 0 (slice(0, -0) = slice(0, 0)) wipes the live node's delta

claude opus 4.8