### PR TITLE
Change inflight range defaut to [256, 512]

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class Hyperbee extends EventEmitter {
       timeout = config.timeout,
       wait = config.wait,
       trace = config.trace,
-      core = _getRootCore(key),
+      core = _getRootCore(store, key, getEncryptionProvider),
       context = new CoreContext(
         store,
         core,

--- a/index.js
+++ b/index.js
@@ -182,6 +182,11 @@ class Hyperbee extends EventEmitter {
 
   async ready() {
     if (!this.core.opened) await this.core.ready()
+    // bump the internal ranges for less roundtrips since interactive
+    if (this.core.replicator.setInflightRange) {
+      this.core.replicator.setInflightRange(256, 512)
+    }
+
     if (this.root) return
     if (this.preload) await this.preload()
     if (this.root) return

--- a/index.js
+++ b/index.js
@@ -26,9 +26,7 @@ class Hyperbee extends EventEmitter {
       timeout = config.timeout,
       wait = config.wait,
       trace = config.trace,
-      core = key
-        ? store.get({ key, encryption: getEncryptionProvider(key) })
-        : store.get({ key, name: 'bee', encryption: getEncryptionProvider(key) }),
+      core = _getRootCore(key),
       context = new CoreContext(
         store,
         core,
@@ -182,10 +180,6 @@ class Hyperbee extends EventEmitter {
 
   async ready() {
     if (!this.core.opened) await this.core.ready()
-    // bump the internal ranges for less roundtrips since interactive
-    if (this.core.replicator.setInflightRange) {
-      this.core.replicator.setInflightRange(256, 512)
-    }
 
     if (this.root) return
     if (this.preload) await this.preload()
@@ -349,4 +343,12 @@ function noop() {}
 function toEncryptionProvider(encryption) {
   if (encryption) return (key) => encryption
   return () => null
+}
+
+function _getRootCore(store, key, getEncryptionProvider) {
+  const encryption = getEncryptionProvider(key)
+
+  return key
+    ? store.get({ key, encryption, inflightRange: [256, 512] })
+    : store.get({ key, name: 'bee', encryption, inflightRange: [256, 512] })
 }

--- a/lib/context.js
+++ b/lib/context.js
@@ -148,7 +148,11 @@ class CoreContext {
     if (index > this.cores.length) throw new Error('Bad core index: ' + index)
     if (this.opened[index - 1] === null) {
       const key = this.cores[index - 1].key
-      this.opened[index - 1] = this.store.get({ key, encryption: this.getEncryptionProvider(key) })
+      this.opened[index - 1] = this.store.get({
+        key,
+        encryption: this.getEncryptionProvider(key),
+        inflightRange: [256, 512]
+      })
     }
     return this.opened[index - 1]
   }
@@ -186,7 +190,11 @@ class CoreContext {
     if (this.other.has(hex)) return this.other.get(hex)
 
     const ctx = this._createContext(
-      this.store.get({ key, encryption: this.getEncryptionProvider(key) })
+      this.store.get({
+        key,
+        encryption: this.getEncryptionProvider(key),
+        inflightRange: [256, 512]
+      })
     )
     this.other.set(hex, ctx)
     return ctx

--- a/test/basic.js
+++ b/test/basic.js
@@ -980,20 +980,6 @@ test('inflight range - default root core (no key given)', async function (t) {
   t.alike(db.core.replicator.inflightRange, INFLIGHT_RANGE)
 })
 
-test('inflight range - root core supplied via opts.core', async function (t) {
-  const store = new Corestore(await t.tmp())
-  t.teardown(() => store.close())
-
-  const core = store.get({ name: 'external' })
-  await core.ready()
-
-  const db = new Bee(store, { core })
-  t.teardown(() => db.close())
-  await db.ready()
-
-  t.alike(db.core.replicator.inflightRange, INFLIGHT_RANGE)
-})
-
 test('inflight range - secondary core opened via context.getCore()', async function (t) {
   const db1 = await create(t)
   {

--- a/test/basic.js
+++ b/test/basic.js
@@ -4,6 +4,8 @@ const Corestore = require('corestore')
 const Bee = require('../')
 const { create, replicate } = require('./helpers')
 
+const INFLIGHT_RANGE = [256, 512]
+
 test('basic', async function (t) {
   const db = await create(t)
   const w = db.write()
@@ -969,4 +971,72 @@ test('lots of overwrites with odd batches', async function (t) {
   }
 
   t.ok(db.root.value.keys.delta.length < 20, 'sanity check')
+})
+
+test('inflight range - default root core (no key given)', async function (t) {
+  const db = await create(t)
+  await db.ready()
+
+  t.alike(db.core.replicator.inflightRange, INFLIGHT_RANGE)
+})
+
+test('inflight range - root core supplied via opts.core', async function (t) {
+  const store = new Corestore(await t.tmp())
+  t.teardown(() => store.close())
+
+  const core = store.get({ name: 'external' })
+  await core.ready()
+
+  const db = new Bee(store, { core })
+  t.teardown(() => db.close())
+  await db.ready()
+
+  t.alike(db.core.replicator.inflightRange, INFLIGHT_RANGE)
+})
+
+test('inflight range - secondary core opened via context.getCore()', async function (t) {
+  const db1 = await create(t)
+  {
+    const w = db1.write()
+    w.tryPut(b4a.from('a'), b4a.from('1'))
+    await w.flush()
+  }
+
+  const db2 = await create(t)
+  replicate(t, db1, db2)
+
+  {
+    const w = db2.write(db1.head())
+    w.tryPut(b4a.from('b'), b4a.from('2'))
+    await w.flush()
+  }
+
+  // 'a' lives on db1's core, so resolving it forces db2's local context
+  // to open db1's core as a secondary core (context.cores[0]) via getCore()
+  const value = await db2.get(b4a.from('a'))
+  t.alike(value.value, b4a.from('1'))
+
+  const hc = db2.context.getCore(1)
+  t.alike(hc.replicator.inflightRange, INFLIGHT_RANGE)
+})
+
+test('inflight range - secondary core opened via context.getContextByKey()', async function (t) {
+  const db1 = await create(t)
+  {
+    const w = db1.write()
+    w.tryPut(b4a.from('a'), b4a.from('1'))
+    await w.flush()
+  }
+
+  const db2 = await create(t)
+  replicate(t, db1, db2)
+
+  // writing on top of a foreign head resolves that key's context via
+  // getContextByKey() during flush()
+  const w = db2.write(db1.head())
+  w.tryPut(b4a.from('b'), b4a.from('2'))
+  await w.flush()
+
+  const ctx = db2.context.getContextByKey(db1.core.key)
+  t.alike(ctx.core.replicator.inflightRange, INFLIGHT_RANGE)
 })


### PR DESCRIPTION
Mirroring `hyperbee`'s [modifying its inflight range](https://github.com/holepunchto/hyperbee/blob/91939de0f30af16b85c2486216e8ba8c02926ab8/index.js#L456) (to avoid additional round trips from requesting fewer blocks from peers), this PR sets the inflight range to a min of `256` and max of `512`.

Added 4 tests for different scenarios where cores are created. The root core is set via `setInflightRange()` because an external core can be passed in instead of gotten via the store.

One caveat to this PR is that if a core is opened external to `hyperbee2` via the same corestore, the options could not be set on that core if it wasn't open with the same inflight range. This is because corestore caches the cores returning existing open cores by id.

Created with help from AI.