### PR TITLE
Clean up inflight range changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Options include:
 }
 ```
 
+If you pass your own `core`, consider increasing the inflight range on it (`256` minimum recommended, e.g. `{ inflightRange: [256, 512] }` when creating the core via Corestore) to match `hyperbee2` constructed cores.
+
 #### `await db.ready()`
 
 Ensures the underlying [Hypercore][hypercore] is ready and prepares the Hyperbee

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class Hyperbee extends EventEmitter {
       timeout = config.timeout,
       wait = config.wait,
       trace = config.trace,
-      core = _getRootCore(store, key, getEncryptionProvider),
+      core = getRootCore(store, key, getEncryptionProvider),
       context = new CoreContext(
         store,
         core,
@@ -342,7 +342,7 @@ function toEncryptionProvider(encryption) {
   return () => null
 }
 
-function _getRootCore(store, key, getEncryptionProvider) {
+function getRootCore(store, key, getEncryptionProvider) {
   const encryption = getEncryptionProvider(key)
 
   return key


### PR DESCRIPTION
- Renames the internal function so it doesnt start with `_`
- Documents that if you pass a `core`, you should set the inflight range.