### PR TITLE
Fix diff issues

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -41,11 +41,9 @@ module.exports = class NodeCache {
   bump(node) {
     if (node === this.latest) return
 
-    if (node.next === null && node.prev === null) {
-      this.byId.set(cacheId(node), node)
-    }
-
+    // remove() drops the index entry, so (re)index after unlinking
     if (node.prev) this.remove(node)
+    this.byId.set(cacheId(node), node)
     this.size++
 
     if (!this.latest) {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -41,9 +41,9 @@ module.exports = class NodeCache {
   bump(node) {
     if (node === this.latest) return
 
-    // remove() drops the index entry, so (re)index after unlinking
-    if (node.prev) this.remove(node)
-    this.byId.set(cacheId(node), node)
+    if (node.prev) this._unlink(node)
+    else this.byId.set(cacheId(node), node)
+
     this.size++
 
     if (!this.latest) {
@@ -63,23 +63,24 @@ module.exports = class NodeCache {
   }
 
   remove(node) {
-    if (node.prev) {
-      this.size--
-
-      if (node === this.latest) {
-        this.latest = node.next === node ? null : node.next
-      }
-
-      node.prev.next = node.next
-      node.next.prev = node.prev
-    }
-
-    node.prev = node.next = null
+    if (node.prev) this._unlink(node)
 
     const id = cacheId(node)
     if (this.byId.get(id) === node) {
       this.byId.delete(id)
     }
+  }
+
+  _unlink(node) {
+    this.size--
+
+    if (node === this.latest) {
+      this.latest = node.next === node ? null : node.next
+    }
+
+    node.prev.next = node.next
+    node.next.prev = node.prev
+    node.prev = node.next = null
   }
 
   *[Symbol.iterator]() {

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -95,7 +95,7 @@ class DiffIterator {
       if (!this.nextLeft) return this._shiftRight()
       if (!this.nextRight) return this._shiftLeft()
 
-      const cmp = b4a.compare(this.nextLeft.key, this.nextRight.key)
+      const cmp = b4a.compare(this.nextLeft.key, this.nextRight.key) * (this.left.reverse ? -1 : 1)
 
       if (cmp === 0) {
         const leftKey = this.nextLeft

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -52,8 +52,37 @@ class DiffIterator {
     }
   }
 
+  // Both sides are about to descend into a child. Identical child pointers mean
+  // identical subtrees, so step over them instead of inflating down to a leaf.
+  async _skipSharedChildren() {
+    if (!this.left.stack.length || !this.right.stack.length) return
+
+    const a = this.left.stack[this.left.stack.length - 1]
+    const b = this.right.stack[this.right.stack.length - 1]
+
+    if ((a.offset & 1) !== 0 || (b.offset & 1) !== 0) return
+
+    const [va, vb] = await Promise.all([inflateTop(this.left, a), inflateTop(this.right, b)])
+
+    const ka = a.offset >> 1
+    const kb = b.offset >> 1
+
+    if (ka >= va.children.length || kb >= vb.children.length) return
+
+    const ca = va.children.get(this.left.reverse ? va.children.length - 1 - ka : ka)
+    const cb = vb.children.get(this.right.reverse ? vb.children.length - 1 - kb : kb)
+
+    if (!isSame(ca, cb)) return
+
+    // skip the child on both sides, the separator keys after it are compared by next()
+    a.offset++
+    b.offset++
+  }
+
   async next() {
     while (this.limit === -1 || this.limit > 0) {
+      if (!this.nextLeft && !this.nextRight) await this._skipSharedChildren()
+
       const leftPromise = this.nextLeft ? null : this.left.nextKey()
       const rightPromise = this.nextRight ? null : this.right.nextKey()
 
@@ -104,10 +133,11 @@ class DiffStream extends Readable {
     this.left = left
     this.right = right
 
+    // prefetching sibling leaves is wasted work in a diff
     this.iterator = new DiffIterator(
       left,
-      new RangeIterator(left, options),
-      new RangeIterator(right, options),
+      new RangeIterator(left, { ...options, prefetch: false }),
+      new RangeIterator(right, { ...options, prefetch: false }),
       options
     )
   }
@@ -140,6 +170,10 @@ class DiffStream extends Readable {
 
 exports.DiffIterator = DiffIterator
 exports.DiffStream = DiffStream
+
+function inflateTop(it, top) {
+  return top.node.value ? it.tree.bump(top.node) : it.tree.inflate(top.node, it.config)
+}
 
 function isSame(a, b) {
   if (a.seq !== b.seq || a.offset !== b.offset) return false

--- a/test/all.js
+++ b/test/all.js
@@ -13,6 +13,7 @@ async function runTests() {
   await import('./diff.js')
   await import('./fuzz.js')
   await import('./fuzz-bad-cache.js')
+  await import('./perf.js')
   await import('./prefetch.js')
   await import('./tree.js')
   await import('./undo.js')

--- a/test/all.js
+++ b/test/all.js
@@ -13,6 +13,7 @@ async function runTests() {
   await import('./diff.js')
   await import('./fuzz.js')
   await import('./fuzz-bad-cache.js')
+  await import('./fuzz-diff.js')
   await import('./perf.js')
   await import('./prefetch.js')
   await import('./tree.js')

--- a/test/diff.js
+++ b/test/diff.js
@@ -1743,6 +1743,76 @@ test('diff cross-writer builds long chain then compares ends', async function (t
   await snap0.close()
 })
 
+test('diff - shared subtrees are skipped without inflating them', async function (t) {
+  // keys are written interleaved across 16 prefixes, so every leaf holds keys
+  // from many different blocks and inflating a leaf costs about one read per key
+  let reads = 0
+  const db = await create(t, { trace: () => reads++ })
+
+  const N = 5000
+  for (let i = 0; i < N; i += 50) {
+    const w = db.write()
+    for (let j = i; j < i + 50; j++) w.tryPut(key(j), b4a.from('v' + j))
+    await w.flush()
+  }
+
+  const snap = db.snapshot()
+
+  {
+    const w = db.write()
+    w.tryPut(key(N), b4a.from('new'))
+    await w.flush()
+  }
+
+  db.context.cache.empty()
+  reads = 0
+  await db.get(key(N >> 1))
+  const getReads = reads
+
+  db.context.cache.empty()
+  reads = 0
+  const entries = await collect(snap.createDiffStream(db))
+  const diffReads = reads
+
+  t.is(entries.length, 1)
+  t.is(entries[0].left, null)
+  t.alike(entries[0].right.key, key(N))
+
+  // only both roots and both versions of the one changed leaf should be inflated
+  t.ok(diffReads < 6 * getReads, `diff read ${diffReads} blocks, a get read ${getReads}`)
+
+  reads = 0
+  await collect(snap.createDiffStream(db))
+  t.is(reads, 0, 'a second diff is served from the node cache')
+
+  await snap.close()
+
+  function key(i) {
+    return b4a.from(String(i % 16).padStart(2, '0') + '/' + String(i).padStart(9, '0'))
+  }
+})
+
+test('cache - a node stays indexed after being bumped again', async function (t) {
+  const db = await create(t)
+
+  for (let i = 0; i < 600; i += 50) {
+    const w = db.write()
+    for (let j = i; j < i + 50; j++) w.tryPut(b4a.from('k' + String(j).padStart(5, '0')), b4a.from('v'))
+    await w.flush()
+  }
+
+  const root = db.root
+  const v = await db.inflate(root, db.config)
+  await db.inflate(v.children.get(0), db.config) // some other node is now most recent
+  db.bump(root) // moves root back to the front of the lru
+
+  t.is(db.context.cache.get(root), root, 'root is still in the cache index')
+
+  const co = db.checkout({ length: db.head().length })
+  t.is(co.root, root, 'checkout reuses the cached root')
+  await co.close()
+})
+
 async function collect(stream) {
   const entries = []
   for await (const entry of stream) {

--- a/test/diff.js
+++ b/test/diff.js
@@ -1797,7 +1797,9 @@ test('cache - a node stays indexed after being bumped again', async function (t)
 
   for (let i = 0; i < 600; i += 50) {
     const w = db.write()
-    for (let j = i; j < i + 50; j++) w.tryPut(b4a.from('k' + String(j).padStart(5, '0')), b4a.from('v'))
+    for (let j = i; j < i + 50; j++) {
+      w.tryPut(b4a.from('k' + String(j).padStart(5, '0')), b4a.from('v'))
+    }
     await w.flush()
   }
 

--- a/test/fuzz-diff.js
+++ b/test/fuzz-diff.js
@@ -1,0 +1,199 @@
+const test = require('brittle')
+const b4a = require('b4a')
+const { create, replicate } = require('./helpers')
+const { DiffIterator } = require('../lib/diff.js')
+
+const RUNS = Number(process.env.RUNS || 20)
+const SEED = Number(process.env.SEED || Date.now() % 1000000)
+
+let skips = 0
+const skipSharedChildren = DiffIterator.prototype._skipSharedChildren
+DiffIterator.prototype._skipSharedChildren = async function () {
+  if (process.env.NOSKIP) return
+  const a = this.left.stack[this.left.stack.length - 1]
+  const before = a ? a.offset : -1
+  await skipSharedChildren.call(this)
+  if (a && a.offset !== before) skips++
+}
+
+test('fuzz diff - single writer', async function (t) {
+  for (let run = 0; run < RUNS; run++) {
+    const seed = SEED + run
+    const rng = random(seed)
+    const opts = { t: pick(rng, [3, 4, 5, 8]), maxCacheSize: pick(rng, [4, 32, 4096]) }
+    const db = await create(t, opts)
+
+    const lengths = []
+    for (let i = 0; i < 4 + rng(8); i++) {
+      await writeBatch(db, rng)
+      lengths.push(db.core.length)
+    }
+
+    // adjacent versions share most of their subtrees
+    const i = rng(lengths.length)
+    const j = rng(2) ? Math.min(i + 1, lengths.length - 1) : rng(lengths.length)
+    const a = db.checkout({ length: lengths[i] })
+    const b = db.checkout({ length: lengths[j] })
+
+    await checkDiffs(t, rng, a, b, `seed ${seed} t=${opts.t} cache=${opts.maxCacheSize}`)
+
+    await a.close()
+    await b.close()
+  }
+
+  t.ok(skips > 0, `shared children were skipped ${skips} times`)
+})
+
+test('fuzz diff - cross writer', async function (t) {
+  for (let run = 0; run < RUNS; run++) {
+    const seed = SEED + 1000000 + run
+    const rng = random(seed)
+    const opts = { t: pick(rng, [3, 4, 5]), maxCacheSize: pick(rng, [4, 4096]) }
+
+    const db1 = await create(t, opts)
+    for (let i = 0; i < 2 + rng(4); i++) await writeBatch(db1, rng)
+
+    const db2 = await create(t, opts)
+    replicate(t, db1, db2)
+
+    const head = db1.head()
+    for (let i = 0; i < 1 + rng(3); i++) await writeBatch(db2, rng, i === 0 ? head : undefined)
+    for (let i = 0; i < rng(3); i++) await writeBatch(db1, rng)
+
+    await checkDiffs(t, rng, db1, db2, `seed ${seed} t=${opts.t} cache=${opts.maxCacheSize}`)
+  }
+})
+
+async function checkDiffs(t, rng, a, b, ctx) {
+  const [ka, kb] = await Promise.all([readAll(a), readAll(b)])
+
+  for (let i = 0; i < 4; i++) {
+    const options = randomOptions(rng)
+    const desc =
+      ctx + ' ' + JSON.stringify(options, (k, v) => (b4a.isBuffer(v) ? b4a.toString(v) : v))
+
+    check(
+      t,
+      strip(await collect(a.createDiffStream(b, options))),
+      reference(ka, kb, options),
+      'a->b ' + desc
+    )
+    check(
+      t,
+      strip(await collect(b.createDiffStream(a, options))),
+      reference(kb, ka, options),
+      'b->a ' + desc
+    )
+  }
+}
+
+function check(t, actual, expected, desc) {
+  const same = JSON.stringify(actual) === JSON.stringify(expected)
+  if (!same && process.env.VERBOSE) {
+    t.comment(
+      'actual   ' + actual.map((e) => e.key + (e.left ? 'L' : '') + (e.right ? 'R' : '')).join(' ')
+    )
+    t.comment(
+      'expected ' +
+        expected.map((e) => e.key + (e.left ? 'L' : '') + (e.right ? 'R' : '')).join(' ')
+    )
+  }
+  t.ok(same, desc)
+}
+
+async function writeBatch(db, rng, head) {
+  const w = db.write(head)
+  const n = 1 + rng(40)
+  for (let i = 0; i < n; i++) {
+    const k = key(rng(300))
+    if (rng(5) === 0) w.tryDelete(k)
+    else w.tryPut(k, b4a.from('v' + rng(1000000)))
+  }
+  await w.flush()
+}
+
+async function readAll(db) {
+  const map = new Map()
+  for await (const e of db.createReadStream()) map.set(b4a.toString(e.key), e)
+  return map
+}
+
+function reference(left, right, options) {
+  const keys = new Set([...left.keys(), ...right.keys()])
+  const out = []
+
+  for (const k of keys) {
+    const l = left.get(k) || null
+    const r = right.get(k) || null
+    if (l && r && samePointer(l, r)) continue
+    if (!inRange(b4a.from(k), options)) continue
+    out.push({ key: k, left: l && b4a.toString(l.value), right: r && b4a.toString(r.value) })
+  }
+
+  out.sort((x, y) => (x.key < y.key ? -1 : x.key > y.key ? 1 : 0))
+  if (options.reverse) out.reverse()
+  if (options.limit !== undefined && options.limit !== -1) {
+    out.length = Math.min(out.length, options.limit)
+  }
+
+  return out
+}
+
+function strip(entries) {
+  return entries.map((e) => ({
+    key: b4a.toString((e.left || e.right).key),
+    left: e.left && b4a.toString(e.left.value),
+    right: e.right && b4a.toString(e.right.value)
+  }))
+}
+
+function samePointer(a, b) {
+  return a.seq === b.seq && a.offset === b.offset && b4a.equals(a.core.key, b.core.key)
+}
+
+function inRange(k, { gt, gte, lt, lte }) {
+  if (gt && b4a.compare(k, gt) <= 0) return false
+  if (gte && b4a.compare(k, gte) < 0) return false
+  if (lt && b4a.compare(k, lt) >= 0) return false
+  if (lte && b4a.compare(k, lte) > 0) return false
+  return true
+}
+
+function randomOptions(rng) {
+  const options = {}
+  if (rng(2)) options.reverse = true
+  const lo = rng(3)
+  const hi = rng(3)
+  if (lo === 1) options.gt = key(rng(300))
+  if (lo === 2) options.gte = key(rng(300))
+  if (hi === 1) options.lt = key(rng(300))
+  if (hi === 2) options.lte = key(rng(300))
+  if (rng(3) === 0) options.limit = rng(6)
+  return options
+}
+
+async function collect(stream) {
+  const entries = []
+  for await (const e of stream) entries.push(e)
+  return entries
+}
+
+function key(i) {
+  return b4a.from(String(i).padStart(4, '0'))
+}
+
+function pick(rng, list) {
+  return list[rng(list.length)]
+}
+
+function random(seed) {
+  let s = seed >>> 0 || 1
+  return function (n) {
+    s ^= s << 13
+    s >>>= 0
+    s ^= s >>> 17
+    s ^= s << 5
+    s >>>= 0
+    return s % n
+  }
+}

--- a/test/perf.js
+++ b/test/perf.js
@@ -1,0 +1,39 @@
+const test = require('brittle')
+const b4a = require('b4a')
+const { create } = require('./helpers')
+
+test('perf - warm tree does no block reads while writing and reading', async function (t) {
+  let reads = 0
+  const db = await create(t, { trace: () => reads++ })
+
+  const N = 20000
+  for (let i = 0; i < N; i += 100) {
+    const w = db.write()
+    for (let j = i; j < i + 100; j++) w.tryPut(key(j), b4a.from('v' + j))
+    await w.flush()
+  }
+
+  for (let i = 0; i < N; i += 7) await db.get(key(i))
+
+  reads = 0
+  const start = Date.now()
+
+  for (let r = 0; r < 200; r++) {
+    const w = db.write()
+    for (let j = 0; j < 20; j++) w.tryPut(key((r * 977 + j * 131) % N), b4a.from('x'))
+    await w.flush()
+
+    for (let j = 0; j < 20; j++) await db.get(key((r * 613 + j * 37) % N))
+
+    const co = db.checkout({ length: db.core.length })
+    await co.get(key(r))
+    await co.close()
+  }
+
+  t.comment(`${reads} block reads, ${Date.now() - start}ms`)
+  t.is(reads, 0, 'everything served from the node cache')
+
+  function key(i) {
+    return b4a.from(String(i).padStart(9, '0'))
+  }
+})


### PR DESCRIPTION
Full transparency: this is a Claude PR that is outside of my wheelhouse, but it seems quite confident in the assessment. Putting it up to get more eyeballs. Will include the last message from the transcript justifying this:

---

Yes, it is a bug. Two bugs, plus one bad default. The design intent is exactly what you say; the code does not implement it.

## Bug 1: the short-circuit is in the wrong place.

DiffIterator in hyperbee2/lib/diff.js only compares node pointers in _fastForward, and _fastForward is only called after both sides have already descended to a leaf, inflated it, and emitted an identical first key. Nothing compares the two child pointers at the parent before descending. So a shared subtree is only detected after paying to inflate its first leaf, and under every internal node that changed, every leaf is inflated on both sides. The root changes on every write, so in a 2-level tree (anything under ~65k keys) that is every leaf in the bee, every diff.

What needs to change: in next(), before calling nextKey(), when both stack tops are about to descend (even offset), compare the two child pointers by core/seq/offset. If they are identical, advance past that child on both sides without inflating it. That is the short-circuit hyperbee's diff has and hyperbee2's is missing.

## Bug 2: the node cache forgets nodes.

NodeCache.bump() in lib/cache.js calls remove() to move a node to the front of the LRU. remove() deletes the node's byId entry. bump() never re-adds it. So any node bumped twice is no longer findable by cache.get(). checkout(from) finds the old root through createTreeNode → cache.get(), so it always misses, and the whole from tree is rebuilt and re-inflated cold on every diff. This is why a warm diff still costs a full scan while a warm get costs zero reads.

What needs to change: bump() must call byId.set() after remove(). One line.

## Bad default: prefetch is on in the diff.

DiffStream passes its options straight to two RangeIterators, which default to prefetch: true. Prefetch speculatively inflates every sibling leaf under the current parent. In a diff that is pure waste and it inflates the whole tree even with bug 1 fixed. DiffStream should force prefetch: false.

Evidence the fixes are right. I patched a scratchpad copy of hyperbee2 with fixes 1 and 2 and reran the same 50k-key, 5-change probe:

| scenario                              | block reads |
|---------------------------------------|-------------|
| stock hyperbee2 (2.14.0)              | 100,658     |
| patched, prefetch on                  | 100,658     |
| patched, prefetch off                 | 3,014       |

50k-key bee written in batches of 50 across 16 prefixes, diffing two heads that differ by 5 keys, counting CoreContext.getBlock calls. For reference a single cold get() on the same bee reads 334 blocks and a full scan reads 50,335. The "patched, prefetch on" row is why the final patch forces prefetch: false inside DiffStream; with that in place the number is 3,014 regardless of what the caller passes.

The one-read-per-key cost of inflating a node is design, not a bug. It only matters here because bugs 1 and 2 make the diff inflate every leaf, cold, every time.
