### PR TITLE
Resolve core table from the referring block, not the tip

### DIFF
--- a/build.js
+++ b/build.js
@@ -237,6 +237,11 @@ bee.register({
       required: true
     },
     {
+      name: 'seq',
+      type: 'uint',
+      constant: 0
+    },
+    {
       name: 'checkpoint',
       type: 'uint',
       required: true
@@ -287,6 +292,11 @@ bee.register({
       name: 'type',
       type: 'uint',
       required: true
+    },
+    {
+      name: 'seq',
+      type: 'uint',
+      constant: 0
     },
     {
       name: 'checkpoint',

--- a/index.js
+++ b/index.js
@@ -278,14 +278,14 @@ class Hyperbee extends EventEmitter {
 
     while (n > 0 && length > 0 && expected === this.unbatch) {
       const seq = length - 1
-      const blk = await context.getBlock(seq, 0, config)
+      const blk = await context.getBlock(seq, 0, config, null)
 
       if (!blk.previous) {
         length = 0
         break
       }
 
-      context = await context.getContext(blk.previous.core, config)
+      context = await context.getContext(blk.previous.core, config, blk)
       length = blk.previous.seq + 1
       n--
     }

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -32,12 +32,12 @@ class ChangesStream extends Readable {
     }
 
     const seq = this.head.length - 1
-    const blk = await this.context.getBlock(seq, 0, this.config)
+    const blk = await this.context.getBlock(seq, 0, this.config, null)
     const batchStart = seq - blk.batch.start
     const remaining = new Array(blk.batch.start)
 
     for (let i = 0; i < remaining.length; i++) {
-      remaining[i] = this.context.getBlock(batchStart + i, 0, this.config)
+      remaining[i] = this.context.getBlock(batchStart + i, 0, this.config, null)
     }
 
     for (const blk of await Promise.all(remaining)) data.batch.push(blk)
@@ -50,7 +50,7 @@ class ChangesStream extends Readable {
       return
     }
 
-    this.context = await this.context.getContext(blk.previous.core, this.config)
+    this.context = await this.context.getContext(blk.previous.core, this.config, blk)
     this.head = data.tail = { key: this.context.core.key, length: blk.previous.seq + 1 }
 
     this.push(data)

--- a/lib/compat.js
+++ b/lib/compat.js
@@ -16,6 +16,7 @@ function decodeCompat(buffer, seq) {
   const index = node ? decodeYoloIndex(node.index) : { levels: [] }
   const morphed = {
     type: 10,
+    seq,
     checkpoint: 0,
     batch: { start: 0, end: 0 },
     previous: seq > 1 ? { core: 0, seq: seq - 1 } : null,

--- a/lib/context.js
+++ b/lib/context.js
@@ -44,10 +44,18 @@ class CoreContext {
     await this._inflateCheckpointFromLength(this.core.length, config, true)
   }
 
-  async updateMaybe(config, core) {
+  // origin is the (already decoded) block in this core that yielded the
+  // reference to `core`, or null. Its checkpoint is enough to resolve the core
+  // table, so prefer it over reading the tip of the core, which might not be available.
+  async updateMaybe(config, core, origin) {
     await this.core.ready()
 
     if (this.hasCore(core)) return
+
+    if (origin !== null) {
+      await this._inflateCheckpoint(origin.seq + 1, origin, config, false)
+      if (this.hasCore(core)) return
+    }
 
     const buf = await this.core.getUserData(CHECKPOINT_KEY)
     const cached = buf ? c.decode(c.uint, buf) : 0
@@ -121,7 +129,7 @@ class CoreContext {
   async getBlockType(core, config) {
     const hc = this.getCore(core)
     if (hc.length === 0) return TYPE_LATEST
-    const block = await this.getBlock(hc.length - 1, core, config)
+    const block = await this.getBlock(hc.length - 1, core, config, null)
     return block.type
   }
 
@@ -154,7 +162,9 @@ class CoreContext {
   }
 
   async getCoreOffset(context, core, config) {
-    if (core !== 0 && core - 1 >= context.cores.length) await context.updateMaybe(config, core)
+    if (core !== 0 && core - 1 >= context.cores.length) {
+      await context.updateMaybe(config, core, null)
+    }
     return this.getCoreOffsetLocal(context, core)
   }
 
@@ -198,8 +208,10 @@ class CoreContext {
     return this.cores[index - 1].key
   }
 
-  async getBlock(seq, core, config) {
-    if (core !== 0 && core - 1 >= this.cores.length) await this.updateMaybe(config, core)
+  async getBlock(seq, core, config, origin) {
+    if (core !== 0 && core - 1 >= this.cores.length) {
+      await this.updateMaybe(config, core, origin)
+    }
 
     const hc = this.getCore(core)
     const buffer = await hc.get(seq, config)
@@ -232,9 +244,9 @@ class CoreContext {
     return ctx
   }
 
-  async getContext(core, config) {
+  async getContext(core, config, origin) {
     if (core === 0) return this
-    if (core > this.cores.length) await this.updateMaybe(config, core)
+    if (core > this.cores.length) await this.updateMaybe(config, core, origin)
     if (core > this.cores.length) throw new Error('Bad core index: ' + core)
 
     const hex = b4a.toString(this.cores[core - 1].key, 'hex')

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -42,6 +42,7 @@ function decodeBlock(buffer, seq) {
   if (type === 1) {
     const block = Block1.decode(state)
     if (block.t === 0) block.t = T
+    block.seq = seq // constant in the schema, so this overwrites rather than adds
     return block
   }
 
@@ -80,6 +81,7 @@ function decodeBlock0(state, seq) {
 
   return {
     type: 0,
+    seq,
     checkpoint: blk.checkpoint,
     batch: blk.batch,
     previous: blk.previous,

--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -17,8 +17,8 @@ exports.inflate = async function inflate(ptr, config) {
 
 async function _inflate(ptr, config) {
   const [block, context] = await Promise.all([
-    ptr.context.getBlock(ptr.seq, ptr.core, config),
-    ptr.context.getContext(ptr.core, config)
+    ptr.context.getBlock(ptr.seq, ptr.core, config, null),
+    ptr.context.getContext(ptr.core, config, null)
   ])
 
   const tree = block.tree[ptr.offset]
@@ -56,7 +56,7 @@ async function inflateKeyDelta(context, d, ptr, block, config) {
   const blk =
     k.seq === ptr.seq && k.core === 0 && ptr.core === 0
       ? block
-      : await context.getBlock(k.seq, k.core, config)
+      : await context.getBlock(k.seq, k.core, config, block)
 
   const bk = blk.keys[k.offset]
 
@@ -64,7 +64,7 @@ async function inflateKeyDelta(context, d, ptr, block, config) {
 
   if (bk.valuePointer) {
     const p = bk.valuePointer
-    const ctx = await context.getContext(k.core, config)
+    const ctx = await context.getContext(k.core, config, block)
     vp = new ValuePointer(ctx, p.core, p.seq, p.offset, p.split)
   }
 
@@ -79,13 +79,13 @@ exports.inflateValue = async function inflateValue(key, config) {
   const ptr = key.valuePointer
 
   if (ptr.split === 0) {
-    const block = await ptr.context.getBlock(ptr.seq, ptr.core, config)
+    const block = await ptr.context.getBlock(ptr.seq, ptr.core, config, null)
     return block.values[ptr.offset]
   }
 
   const blockPromises = new Array(ptr.split + 1)
   for (let i = 0; i < blockPromises.length; i++) {
-    blockPromises[i] = ptr.context.getBlock(ptr.seq - ptr.split + i, ptr.core, config)
+    blockPromises[i] = ptr.context.getBlock(ptr.seq - ptr.split + i, ptr.core, config, null)
   }
   const blocks = await Promise.all(blockPromises)
   const splitValue = new Array(blockPromises.length)
@@ -102,11 +102,11 @@ async function inflateKeyCohort(context, d, ptr, block, config) {
   const blk =
     co.seq === ptr.seq && co.core === 0 && ptr.core === 0
       ? block
-      : await context.getBlock(co.seq, co.core, config)
+      : await context.getBlock(co.seq, co.core, config, block)
 
   const cohort = blk.cohorts[co.offset]
   const promises = new Array(cohort.length)
-  const ctx = await context.getContext(co.core, config)
+  const ctx = await context.getContext(co.core, config, block)
 
   for (let i = 0; i < cohort.length; i++) {
     const p = cohort[i]
@@ -121,7 +121,7 @@ async function inflateKeyCohort(context, d, ptr, block, config) {
 async function inflateChild(context, d, ptr, block, config) {
   if (d.type === OP_COHORT) return inflateChildCohort(context, d, ptr, block, config)
   if (d.pointer && !context.hasCore(d.pointer.core)) {
-    await context.updateMaybe(config, d.pointer.core)
+    await context.updateMaybe(config, d.pointer.core, block)
   }
   return inflateChildDelta(context, d, ptr, block, config)
 }
@@ -138,15 +138,17 @@ async function inflateChildCohort(context, d, ptr, block, config) {
   const blk =
     co.seq === ptr.seq && co.core === 0 && ptr.core === 0
       ? block
-      : await context.getBlock(co.seq, co.core, config)
+      : await context.getBlock(co.seq, co.core, config, block)
 
   const cohort = blk.cohorts[co.offset]
   const deltas = new Array(cohort.length)
-  const ctx = await context.getContext(co.core, config)
+  const ctx = await context.getContext(co.core, config, block)
 
   for (let i = 0; i < cohort.length; i++) {
     const c = cohort[i]
-    if (c.pointer && !ctx.hasCore(c.pointer.core)) await ctx.updateMaybe(config, c.pointer.core)
+    if (c.pointer && !ctx.hasCore(c.pointer.core)) {
+      await ctx.updateMaybe(config, c.pointer.core, blk)
+    }
     deltas[i] = inflateChildDelta(ctx, c, co, blk, config)
   }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "compact-encoding": "^3.0.0",
     "hypercore": "^11.29.0",
     "hypercore-errors": "^1.5.0",
-    "hyperschema": "^1.14.0",
+    "hyperschema": "^1.26.1",
     "protocol-buffers-encodings": "^1.2.0",
     "scope-lock": "^1.2.4",
     "streamx": "^2.22.1"

--- a/spec/hyperschema/index.js
+++ b/spec/hyperschema/index.js
@@ -365,11 +365,11 @@ const encoding11 = {
 }
 
 // @bee/block-0.tree
-const encoding12_4 = c.array(encoding7)
+const encoding12_5 = c.array(encoding7)
 // @bee/block-0.data
-const encoding12_5 = c.array(encoding9)
+const encoding12_6 = c.array(encoding9)
 // @bee/block-0.cores
-const encoding12_6 = c.array(encoding11)
+const encoding12_7 = c.array(encoding11)
 
 // @bee/block-0
 const encoding12 = {
@@ -380,9 +380,9 @@ const encoding12 = {
     state.end++ // max flag is 8 so always one byte
 
     if (m.previous) encoding5.preencode(state, m.previous)
-    if (m.tree) encoding12_4.preencode(state, m.tree)
-    if (m.data) encoding12_5.preencode(state, m.data)
-    if (m.cores) encoding12_6.preencode(state, m.cores)
+    if (m.tree) encoding12_5.preencode(state, m.tree)
+    if (m.data) encoding12_6.preencode(state, m.data)
+    if (m.cores) encoding12_7.preencode(state, m.cores)
   },
   encode(state, m) {
     const flags = (m.previous ? 1 : 0) | (m.tree ? 2 : 0) | (m.data ? 4 : 0) | (m.cores ? 8 : 0)
@@ -393,30 +393,31 @@ const encoding12 = {
     c.uint.encode(state, flags)
 
     if (m.previous) encoding5.encode(state, m.previous)
-    if (m.tree) encoding12_4.encode(state, m.tree)
-    if (m.data) encoding12_5.encode(state, m.data)
-    if (m.cores) encoding12_6.encode(state, m.cores)
+    if (m.tree) encoding12_5.encode(state, m.tree)
+    if (m.data) encoding12_6.encode(state, m.data)
+    if (m.cores) encoding12_7.encode(state, m.cores)
   },
   decode(state) {
     const r0 = c.uint.decode(state)
-    const r1 = c.uint.decode(state)
-    const r2 = encoding6.decode(state)
+    const r2 = c.uint.decode(state)
+    const r3 = encoding6.decode(state)
     const flags = c.uint.decode(state)
 
     return {
       type: r0,
-      checkpoint: r1,
-      batch: r2,
+      seq: 0,
+      checkpoint: r2,
+      batch: r3,
       previous: (flags & 1) !== 0 ? encoding5.decode(state) : null,
-      tree: (flags & 2) !== 0 ? encoding12_4.decode(state) : null,
-      data: (flags & 4) !== 0 ? encoding12_5.decode(state) : null,
-      cores: (flags & 8) !== 0 ? encoding12_6.decode(state) : null
+      tree: (flags & 2) !== 0 ? encoding12_5.decode(state) : null,
+      data: (flags & 4) !== 0 ? encoding12_6.decode(state) : null,
+      cores: (flags & 8) !== 0 ? encoding12_7.decode(state) : null
     }
   }
 }
 
 // @bee/metadata.cores
-const encoding13_0 = encoding12_6
+const encoding13_0 = encoding12_7
 
 // @bee/metadata
 const encoding13 = {
@@ -436,15 +437,15 @@ const encoding13 = {
 }
 
 // @bee/block-1.metadata
-const encoding14_4 = c.frame(encoding13)
+const encoding14_5 = c.frame(encoding13)
 // @bee/block-1.tree
-const encoding14_5 = c.array(encoding8)
+const encoding14_6 = c.array(encoding8)
 // @bee/block-1.keys
-const encoding14_6 = c.array(encoding10)
+const encoding14_7 = c.array(encoding10)
 // @bee/block-1.values
-const encoding14_7 = c.array(c.buffer)
+const encoding14_8 = c.array(c.buffer)
 // @bee/block-1.cohorts
-const encoding14_8 = c.array(encoding3)
+const encoding14_9 = c.array(encoding3)
 
 // @bee/block-1
 const encoding14 = {
@@ -455,11 +456,11 @@ const encoding14 = {
     state.end++ // max flag is 64 so always one byte
 
     if (m.previous) encoding5.preencode(state, m.previous)
-    if (m.metadata) encoding14_4.preencode(state, m.metadata)
-    if (m.tree) encoding14_5.preencode(state, m.tree)
-    if (m.keys) encoding14_6.preencode(state, m.keys)
-    if (m.values) encoding14_7.preencode(state, m.values)
-    if (m.cohorts) encoding14_8.preencode(state, m.cohorts)
+    if (m.metadata) encoding14_5.preencode(state, m.metadata)
+    if (m.tree) encoding14_6.preencode(state, m.tree)
+    if (m.keys) encoding14_7.preencode(state, m.keys)
+    if (m.values) encoding14_8.preencode(state, m.values)
+    if (m.cohorts) encoding14_9.preencode(state, m.cohorts)
     if (m.t) c.uint.preencode(state, m.t)
   },
   encode(state, m) {
@@ -478,29 +479,30 @@ const encoding14 = {
     c.uint.encode(state, flags)
 
     if (m.previous) encoding5.encode(state, m.previous)
-    if (m.metadata) encoding14_4.encode(state, m.metadata)
-    if (m.tree) encoding14_5.encode(state, m.tree)
-    if (m.keys) encoding14_6.encode(state, m.keys)
-    if (m.values) encoding14_7.encode(state, m.values)
-    if (m.cohorts) encoding14_8.encode(state, m.cohorts)
+    if (m.metadata) encoding14_5.encode(state, m.metadata)
+    if (m.tree) encoding14_6.encode(state, m.tree)
+    if (m.keys) encoding14_7.encode(state, m.keys)
+    if (m.values) encoding14_8.encode(state, m.values)
+    if (m.cohorts) encoding14_9.encode(state, m.cohorts)
     if (m.t) c.uint.encode(state, m.t)
   },
   decode(state) {
     const r0 = c.uint.decode(state)
-    const r1 = c.uint.decode(state)
-    const r2 = encoding6.decode(state)
+    const r2 = c.uint.decode(state)
+    const r3 = encoding6.decode(state)
     const flags = c.uint.decode(state)
 
     return {
       type: r0,
-      checkpoint: r1,
-      batch: r2,
+      seq: 0,
+      checkpoint: r2,
+      batch: r3,
       previous: (flags & 1) !== 0 ? encoding5.decode(state) : null,
-      metadata: (flags & 2) !== 0 ? encoding14_4.decode(state) : null,
-      tree: (flags & 4) !== 0 ? encoding14_5.decode(state) : null,
-      keys: (flags & 8) !== 0 ? encoding14_6.decode(state) : null,
-      values: (flags & 16) !== 0 ? encoding14_7.decode(state) : null,
-      cohorts: (flags & 32) !== 0 ? encoding14_8.decode(state) : null,
+      metadata: (flags & 2) !== 0 ? encoding14_5.decode(state) : null,
+      tree: (flags & 4) !== 0 ? encoding14_6.decode(state) : null,
+      keys: (flags & 8) !== 0 ? encoding14_7.decode(state) : null,
+      values: (flags & 16) !== 0 ? encoding14_8.decode(state) : null,
+      cohorts: (flags & 32) !== 0 ? encoding14_9.decode(state) : null,
       t: (flags & 64) !== 0 ? c.uint.decode(state) : 0
     }
   }

--- a/spec/hyperschema/schema.json
+++ b/spec/hyperschema/schema.json
@@ -270,11 +270,17 @@
       "name": "block-0",
       "namespace": "bee",
       "compact": false,
-      "flagsPosition": 3,
+      "flagsPosition": 4,
       "fields": [
         {
           "name": "type",
           "required": true,
+          "type": "uint",
+          "version": 1
+        },
+        {
+          "name": "seq",
+          "constant": 0,
           "type": "uint",
           "version": 1
         },
@@ -334,11 +340,17 @@
       "name": "block-1",
       "namespace": "bee",
       "compact": false,
-      "flagsPosition": 3,
+      "flagsPosition": 4,
       "fields": [
         {
           "name": "type",
           "required": true,
+          "type": "uint",
+          "version": 1
+        },
+        {
+          "name": "seq",
+          "constant": 0,
           "type": "uint",
           "version": 1
         },

--- a/test/checkpoint.js
+++ b/test/checkpoint.js
@@ -72,6 +72,76 @@ test('offline reader can move to cached checkpoint after learning a newer length
   }
 })
 
+test('core table resolves from the referring block, not the tip of the core', async function (t) {
+  // db2 block 0 references db1, block 1 introduces a new checkpoint that also
+  // references db3, block 2 is a plain append. A reader that only has block 1
+  // locally must be able to resolve db3 from block 1's checkpoint without
+  // touching block 2 (the tip), which it does not have.
+  const db1 = await create(t)
+  {
+    const w = db1.write()
+    w.tryPut(b4a.from('a'), b4a.from('1'))
+    await w.flush()
+  }
+
+  const db3 = await create(t)
+  {
+    const w = db3.write()
+    w.tryPut(b4a.from('x'), b4a.from('9'))
+    await w.flush()
+  }
+
+  const db2 = await create(t)
+  replicate(t, db1, db2)
+  replicate(t, db3, db2)
+  {
+    const w = db2.write(db1.head())
+    w.tryPut(b4a.from('b'), b4a.from('2'))
+    await w.flush()
+  }
+  {
+    const w = db2.write(db3.head())
+    w.tryPut(b4a.from('c'), b4a.from('3'))
+    await w.flush()
+  }
+  {
+    const w = db2.write()
+    w.tryPut(b4a.from('d'), b4a.from('4'))
+    await w.flush()
+  }
+  t.is(db2.core.length, 3)
+
+  const store = new Corestore(await t.tmp())
+  t.teardown(() => store.close())
+
+  const reader = new Bee(store, { key: db2.core.key, writable: false })
+  t.teardown(() => reader.close())
+  await reader.ready()
+
+  const appended = new Promise((resolve) => reader.core.once('append', resolve))
+  const stop = replicateManual(reader, db2)
+  await appended
+  t.is(reader.core.length, 3)
+
+  // only fetch the block we are going to read from, never the tip
+  await reader.core.get(1)
+  await stop()
+
+  t.is(await reader.core.has(1), true)
+  t.is(await reader.core.has(2), false, 'tip is not local')
+
+  // db3 is reachable, db2 is not
+  const c3 = store.get({ key: db3.core.key })
+  await c3.ready()
+  replicate(t, reader, db3)
+  await c3.get(0)
+
+  reader.move({ length: 2 })
+
+  t.alike((await reader.get(b4a.from('x'), { wait: false })).value, b4a.from('9'))
+  t.alike((await reader.get(b4a.from('c'), { wait: false })).value, b4a.from('3'))
+})
+
 function replicateManual(a, b) {
   const s1 = a.replicate(true)
   const s2 = b.replicate(false)


### PR DESCRIPTION
Pass the already decoded block that yielded a core reference (origin) down through getBlock/getContext/updateMaybe so the core table can be inflated from that block's checkpoint. Readers that only hold the block they are reading no longer have to fetch the tip of the core to resolve cores.

Blocks now carry their seq (a schema constant, never encoded) so the origin path knows which length it resolves. Bump hyperschema to 1.26.1 for the constant field option and the bitwise uint decode fix.