### PR TITLE
Add timeout and wait options to checkout, snapshot and undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Options:
   writable: false,           // Boolean. Will the new tree be writable?
   length: this.core.length,  // Number. Length of blocks used from the Hypercore
   key: null,                 // Buffer or null. Key of the Hypercore
+  timeout: this.timeout,     // Number. Wait at most this many milliseconds per Hypercore read (0 means no timeout)
+  wait: this.wait,           // Boolean. Wait for Hypercore to download blocks
 }
 ```
 
@@ -157,14 +159,32 @@ Options:
 }
 ```
 
-#### `db.snapshot()`
+#### `db.snapshot([options])`
 
 Returns a new Hyperbee that is a read only view of the current tree.
 
-#### `db.undo(n)`
+Options:
+
+```js
+{
+  timeout: this.timeout,     // Number. Wait at most this many milliseconds per Hypercore read (0 means no timeout)
+  wait: this.wait,           // Boolean. Wait for Hypercore to download blocks
+}
+```
+
+#### `db.undo(n, [options])`
 
 Returns a new Hyperbee that is a writable view of the current tree,
 with the last `n` write batches ignored.
+
+Options:
+
+```js
+{
+  timeout: this.timeout,     // Number. Wait at most this many milliseconds per Hypercore read (0 means no timeout)
+  wait: this.wait,           // Boolean. Wait for Hypercore to download blocks
+}
+```
 
 #### `db.write([options])`
 

--- a/index.js
+++ b/index.js
@@ -101,12 +101,14 @@ class Hyperbee extends EventEmitter {
     return this.store.replicate(...opts)
   }
 
-  _makeView(context, root, writable, unbatch) {
+  _makeView(context, root, writable, unbatch, timeout, wait) {
     return new Hyperbee(this.store, {
       t: this.t,
       config: this.config,
       core: context.core,
       activeRequests: [],
+      timeout,
+      wait,
       context,
       root,
       view: true,
@@ -117,10 +119,16 @@ class Hyperbee extends EventEmitter {
     })
   }
 
-  checkout({ length = this.core.length, key = null, writable = false } = {}) {
+  checkout({
+    length = this.core.length,
+    key = null,
+    writable = false,
+    timeout = this.config.timeout,
+    wait = this.config.wait
+  } = {}) {
     const context = key ? this.context.getContextByKey(key) : this.context
     const root = length === 0 ? EMPTY : context.createTreeNode(0, length - 1, 0, false, null)
-    return this._makeView(context, root, writable, 0)
+    return this._makeView(context, root, writable, 0, timeout, wait)
   }
 
   move({ length = this.core.length, key = null, writable = this.writable } = {}) {
@@ -130,12 +138,12 @@ class Hyperbee extends EventEmitter {
     this._setRoot(this._nodeAtSeq(length - 1), true)
   }
 
-  snapshot() {
-    return this._makeView(this.context, this.root, false, 0)
+  snapshot({ timeout = this.config.timeout, wait = this.config.wait } = {}) {
+    return this._makeView(this.context, this.root, false, 0, timeout, wait)
   }
 
-  undo(n) {
-    return this._makeView(this.context, this.root, true, n)
+  undo(n, { timeout = this.config.timeout, wait = this.config.wait } = {}) {
+    return this._makeView(this.context, this.root, true, n, timeout, wait)
   }
 
   write(opts = {}) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -1169,3 +1169,86 @@ test('cores() lists the own core and referenced cores', async function (t) {
   t.alike(await reader.cores(), [db2.core.key, db1.core.key])
   t.alike(await reader.cores({ local: false }), [db1.core.key])
 })
+
+test('checkout with timeout and wait options', async function (t) {
+  const db = await create(t)
+
+  const w = db.write()
+  w.tryPut(b4a.from('a'), b4a.from('1'))
+  await w.flush()
+
+  // reader that never replicates, so every read of a missing block hangs
+  const reader = await create(t, { key: db.core.key })
+  await reader.ready()
+
+  const inherited = reader.checkout({ length: db.head().length })
+  t.is(inherited.config.timeout, reader.config.timeout, 'inherits timeout by default')
+  t.is(inherited.config.wait, reader.config.wait, 'inherits wait by default')
+  await inherited.close()
+
+  const timedOut = reader.checkout({ length: db.head().length, timeout: 100 })
+  t.is(timedOut.config.timeout, 100)
+  await t.exception(timedOut.get(b4a.from('a')), /REQUEST_TIMEOUT/)
+  await timedOut.close()
+
+  const noWait = reader.checkout({ length: db.head().length, wait: false })
+  t.is(noWait.config.wait, false)
+  await t.exception(noWait.get(b4a.from('a')), /BLOCK_NOT_AVAILABLE/)
+  await noWait.close()
+})
+
+test('snapshot with timeout and wait options', async function (t) {
+  const db = await create(t)
+
+  const w = db.write()
+  w.tryPut(b4a.from('a'), b4a.from('1'))
+  await w.flush()
+
+  const reader = await create(t, { key: db.core.key })
+  await reader.ready()
+  reader.move({ length: db.head().length })
+
+  const inherited = reader.snapshot()
+  t.is(inherited.config.timeout, reader.config.timeout, 'inherits timeout by default')
+  t.is(inherited.config.wait, reader.config.wait, 'inherits wait by default')
+  await inherited.close()
+
+  const timedOut = reader.snapshot({ timeout: 100 })
+  t.is(timedOut.config.timeout, 100)
+  await t.exception(timedOut.get(b4a.from('a')), /REQUEST_TIMEOUT/)
+  await timedOut.close()
+
+  const noWait = reader.snapshot({ wait: false })
+  t.is(noWait.config.wait, false)
+  await t.exception(noWait.get(b4a.from('a')), /BLOCK_NOT_AVAILABLE/)
+  await noWait.close()
+})
+
+test('undo with timeout and wait options', async function (t) {
+  const db = await create(t)
+
+  for (let i = 0; i < 2; i++) {
+    const w = db.write()
+    w.tryPut(b4a.from('a'), b4a.from('' + i))
+    await w.flush()
+  }
+
+  const reader = await create(t, { key: db.core.key })
+  await reader.ready()
+  reader.move({ length: db.head().length })
+
+  const inherited = reader.undo(1)
+  t.is(inherited.config.timeout, reader.config.timeout, 'inherits timeout by default')
+  t.is(inherited.config.wait, reader.config.wait, 'inherits wait by default')
+  await inherited.close()
+
+  const timedOut = reader.undo(1, { timeout: 100 })
+  t.is(timedOut.config.timeout, 100)
+  await t.exception(timedOut.get(b4a.from('a')), /REQUEST_TIMEOUT/)
+  await timedOut.close()
+
+  const noWait = reader.undo(1, { wait: false })
+  t.is(noWait.config.wait, false)
+  await t.exception(noWait.get(b4a.from('a')), /BLOCK_NOT_AVAILABLE/)
+  await noWait.close()
+})


### PR DESCRIPTION
Views inherit the parent bee's timeout and wait by default. The options let a caller override them per view so every hypercore read done through that view is bounded, e.g. when warming up a fast-forward candidate.